### PR TITLE
Add section about DCO to the contributors' guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,82 @@ Make sure the description of the PR clearly explains the motivation
 and link to any other resources we might need to consider when
 reviewing.
 
+# Developer Certificate of Origin
+
+The [`DCO GitHub plugin`](https://github.com/apps/dco) is enabled on
+all repositories in the `ingraind` organization. This plugin will
+check if *all* your commits in a PR have signed off on the Developer
+Certificate of Origin.
+
+A sign-off looks like this at the end of your Git commit message:
+
+	Signed-off-by: Peter Parkanyi <peter@redsift.io>
+
+
+Having this line appended to your commits proves that you agree to the
+following document:
+
+
+	Developer Certificate of Origin
+	Version 1.1
+
+	Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+	660 York Street, Suite 102,
+	San Francisco, CA 94110 USA
+
+	Everyone is permitted to copy and distribute verbatim copies of this
+	license document, but changing it is not allowed.
+
+
+	Developer's Certificate of Origin 1.1
+
+	By making a contribution to this project, I certify that:
+
+	(a) The contribution was created in whole or in part by me and I
+		have the right to submit it under the open source license
+		indicated in the file; or
+
+	(b) The contribution is based upon previous work that, to the best
+		of my knowledge, is covered under an appropriate open source
+		license and I have the right under that license to submit that
+		work with modifications, whether created in whole or in part
+		by me, under the same open source license (unless I am
+		permitted to submit under a different license), as indicated
+		in the file; or
+
+	(c) The contribution was provided directly to me by some other
+		person who certified (a), (b) or (c) and I have not modified
+		it.
+
+	(d) I understand and agree that this project and the contribution
+		are public and that a record of the contribution (including all
+		personal information I submit with it, including my sign-off) is
+		maintained indefinitely and may be redistributed consistent with
+		this project or the open source license(s) involved.
+
+To make the developer process more efficient, you can use the `git
+commit -s` command instead of your usual `git commit` command line to
+automatically append the sign-off line to every commit you make.
+
+You can also make this the default behaviour by changing your Git config:
+
+	git config --add alias.amend "commit -s --amend"
+	git config --add alias.c "commit -s"
+
+### Fixing DCO errors
+
+If a single commit doesn't contain the sign-off line, the CI will not
+allow your PR to be merged.
+
+You will need to `git push --force` to the PR with the amended commit
+messages to fix this error.
+
+Alternatively, you can squash the commits to add the sign-off line, assuming you
+diverged your branch from `main`, like so:
+
+	git rebase -i main # interactive squash
+	git push origin -f
+
 ## What if I don't know Rust?
 
 If you don't know Rust, and still enjoy tinkering on the project,


### PR DESCRIPTION
As per CNCF requirements, contributors need to sign the attached Developer's Certificate of Origin in their Git commits. This is checked by the DCO plugin that's already enabled on every repository in the organization to enforce this requirement.