### PR TITLE
Remove Deepak Prabhakara from list of Maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,4 +4,6 @@
 
 Peter Parkanyi <peter@redsift.io> @rsdy
 Junyeong Jeong <rhdxmr@gmail.com> @rhdxmr
+
+# Retired
 Deepak Prabhakara <deepak@redsift.io> @deepakprabhakara


### PR DESCRIPTION
As @deepakprabhakara is no longer with Red Sift, and hasn't contributed to the project throughout his membership, I propose the removal of his maintainer rights.

Of course, we welcome any further contributions, and we may consider extending the maintainer rights again as we see fit.

This proposition requires 1 approval to be merged by either @deepakprabhakara or @rhdxmr .